### PR TITLE
Unsubscribe immediately when callbag receives 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,20 +6,16 @@ const create = prod => (start, sink) => {
     return;
   }
   let end;
-  let got2;
   let unsub;
-  sink(0, t => {
-    got2 = got2 || t === 2;
-  });
+  const maybeDispose = t => {
+    end = end || t === 2;
+    if (end && typeof unsub === 'function') unsub();
+  };
+  sink(0, maybeDispose);
   unsub = prod((t, d) => {
     if (end || t === 0) return;
-    if (!got2) {
-      sink(t, d);
-      got2 = got2 || t === 2;
-    } else if (!end) {
-      end = true;
-      if (unsub) unsub();
-    }
+    sink(t, d);
+    maybeDispose(t);
   });
 };
 


### PR DESCRIPTION
With previous version of the code the `unsub` was not called when:
- 2 was received from the sink
- 2 was produced by a producer

It was called after producer produced something AFTER receiving 2. This was imho too late as resources should be freed asap.

I've also simplified slightly the implementation - got rid of 2 separate flags (`got2` and `end`) in favour of a single `end`.

Didn't have time to write a test for this now (existing tests pass), can do it later.